### PR TITLE
Fix radiobutton focused state

### DIFF
--- a/generic/gtkTtk_RadioButton.cpp
+++ b/generic/gtkTtk_RadioButton.cpp
@@ -51,7 +51,7 @@ static void RadioButtonIndicatorElementDraw(
     Drawable d, Ttk_Box b, unsigned state)
 {
     GTKTTK_GTK_DRAWABLE_DEFINITIONS;
-    gint indicator_size, x, y, focus_pad;
+    gint indicator_size, x, y;
     const gint MAGIC_HEIGHT_WIDTH_COMPLEMENT = 40;
     GTKTTK_ENSURE_GTK_STYLE_ENGINE_ACTIVE;
     GtkWidget *widget = GtkTtk_GetRadioButton(wc);

--- a/generic/gtkTtk_RadioButton.cpp
+++ b/generic/gtkTtk_RadioButton.cpp
@@ -57,28 +57,23 @@ static void RadioButtonIndicatorElementDraw(
     GtkWidget *widget = GtkTtk_GetRadioButton(wc);
     GTKTTK_ENSURE_WIDGET_OK;
     GTKTTK_DRAWABLE_FROM_WIDGET_SIZE(b.width+MAGIC_HEIGHT_WIDTH_COMPLEMENT,
-				     b.height+MAGIC_HEIGHT_WIDTH_COMPLEMENT);
+				    b.height+MAGIC_HEIGHT_WIDTH_COMPLEMENT);
     GTKTTK_STYLE_BACKGROUND_DEFAULT;
-    GTKTTK_DEFAULT_BACKGROUND_SIZE(b.width+MAGIC_HEIGHT_WIDTH_COMPLEMENT
-				   , b.height+MAGIC_HEIGHT_WIDTH_COMPLEMENT);
+    GTKTTK_DEFAULT_BACKGROUND_SIZE(b.width+MAGIC_HEIGHT_WIDTH_COMPLEMENT,
+                    b.height+MAGIC_HEIGHT_WIDTH_COMPLEMENT);
     GTKTTK_STYLE_FROM_WIDGET;
     GTKTTK_WIDGET_SET_FOCUS(widget);
     GtkTtk_gtk_widget_style_get(widget,
-           "indicator-size", &indicator_size, 
-	   "focus-padding",     &focus_pad, NULL);
+           "indicator-size", &indicator_size, NULL);
     GtkTtk_StateShadowTableLookup(NULL, state, gtkState, gtkShadow,
             GTKTTK_SECTION_BUTTONS|GTKTTK_SECTION_ALL);
-    if (state & TTK_STATE_FOCUS) {
-      GtkTtk_gtk_paint_focus(style, gdkDrawable, gtkState, NULL, widget,
-              "radiobutton", 0, 0, b.width + indicator_size, b.height + indicator_size);
-    }
     // GtkTtk_StateInfo(state, gtkState, gtkShadow, tkwin, widget);
-    x = b.width  - indicator_size / 2;
-    y = b.height - indicator_size / 2 -focus_pad;
+    x = (b.width  - indicator_size) / 2;
+    y = (b.height - indicator_size) / 2;
     GtkTtk_gtk_paint_option(style, gdkDrawable, gtkState, gtkShadow, NULL,
             widget, "radiobutton", x, y, indicator_size, indicator_size);
     GtkTtk_CopyGtkPixmapOnToDrawable(gdkDrawable, d, tkwin,
-            b.width/2, b.height/2, b.width + indicator_size, b.height + indicator_size, b.x, b.y);
+            0, 0, b.width, b.height, b.x, b.y);
     GTKTTK_CLEANUP_GTK_DRAWABLE;
 }
 


### PR DESCRIPTION
Currently the radiobutton is quite glitchy when focused. Mostly because of the changes introduced in e34864a06d990a306f4835566a3e781f2caec915.

Sometimes they don't render at all:
![image](https://user-images.githubusercontent.com/77941087/209234862-8d35c997-ee76-4575-bd65-256f2cbe394b.png)


While printing a bunch of errors.
```yaml
(wish:52092): Gdk-CRITICAL **: 23:05:05.778: IA__gdk_pixbuf_get_from_drawable: assertion 'src_x + width <= src_width && src_y + height <= src_height' failed

** (wish:52092): CRITICAL **: 23:05:05.778: gdk_pixbuf_xlib_render_to_drawable: assertion 'pixbuf != NULL' failed

(wish:52092): GLib-GObject-CRITICAL **: 23:05:05.778: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```
and with some Gtk themes it looks like this:
![image](https://user-images.githubusercontent.com/77941087/209234571-a966d7eb-5a02-42a7-b1b8-362024976bc7.png)


This patch fixes these bugs. I removed the focus padding stuff, and copied most parts of the checkbutton code, which works well.

![image](https://user-images.githubusercontent.com/77941087/209234743-9700d5df-f774-4335-8c4a-0670250fceea.png)
![image](https://user-images.githubusercontent.com/77941087/209234779-50bb5a31-5ba1-480c-8eea-a11c041bf35a.png)
